### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,7 +5,7 @@
 		<link rel="stylesheet" href="{{ .Site.BaseURL }}css/text.css">
 		<link rel="shortcut icon" href="{{ .Site.BaseURL }}favicon.ico">
 		<link rel="icon" type="image/png" href="{{ .Site.BaseURL }}favicon-192.png" sizes="192x192">
-		<link rel="apple-touch-icon" sizes="180x180" href="{{ .Site.BaseURL }}favicon-180.png">		<link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+		<link rel="apple-touch-icon" sizes="180x180" href="{{ .Site.BaseURL }}favicon-180.png">		<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 		{{ range .Site.Params.CSS }}
 		<link rel="stylesheet" href="{{ $.Site.BaseURL }}{{ . }}"/>{{ end }}
 {{ partial "head-local.html" . }}


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.